### PR TITLE
fix: add missing HttpModule import and wait for RabbitMQ readiness

### DIFF
--- a/app/src/trades/trades.module.ts
+++ b/app/src/trades/trades.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TradesRabbitService } from './trades-rabbit.service';
 import { TradesService } from './trades.service';
 import { RabbitMQWrapperModule } from 'src/rabbitmq-wrapper/rabbitmq-wrapper.module';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [RabbitMQWrapperModule],
+  imports: [RabbitMQWrapperModule, HttpModule],
   providers: [TradesRabbitService, TradesService],
 })
 export class TradesModule {}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -34,6 +34,13 @@ services:
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
     volumes:
       - 'rabbitmq:/var/lib/rabbitmq'
+    healthcheck:
+      test: rabbitmq-diagnostics ping
+      interval: 60s
+      timeout: 5s
+      retries: 2
+      start_period: 30s
+      start_interval: 10s
 
   minio:
     image: minio/minio:RELEASE.2023-02-17T17-52-43Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
     volumes:
       - 'rabbitmq:/var/lib/rabbitmq'
+    healthcheck:
+      test: rabbitmq-diagnostics check_port_connectivity
+      start_period: 60s
+      interval: 5s
+      timeout: 1s
+      retries: 3
 
   minio:
     image: minio/minio:RELEASE.2023-02-17T17-52-43Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,11 +37,12 @@ services:
     volumes:
       - 'rabbitmq:/var/lib/rabbitmq'
     healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivity
-      start_period: 60s
-      interval: 5s
-      timeout: 1s
-      retries: 3
+      test: rabbitmq-diagnostics ping
+      interval: 60s
+      timeout: 5s
+      retries: 2
+      start_period: 30s
+      start_interval: 10s
 
   minio:
     image: minio/minio:RELEASE.2023-02-17T17-52-43Z


### PR DESCRIPTION
This PR fixes a missing import and improves service startup reliability by ensuring RabbitMQ is ready before other components initialize.