### PR TITLE
feat: Switch minio with seaweedfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 - `cd app && yarn install`
 - create a `.env` file from the template at `template.env`
 - create a `/bots/bot1.env` file from the template at `/bots/template.env` and add your bots account info
-- start the minio service
-- go to http://localhost:9001
-- create a bucket called `tf2-automatic`
-- start everything
+- create `s3_config.json` file from the template at `template.s3_config.json` and make sure seaweed credentials match with `/bots/*.env`
 
 # Developing your app
 Just write your code in the `./app` folder!  

--- a/bots/template.env
+++ b/bots/template.env
@@ -8,13 +8,13 @@ STEAM_IDENTITY_SECRET=''
 # You can leave these as they are, unless you know what you're doing
 # Storage settings
 STORAGE_TYPE='s3'
-STORAGE_S3_ENDPOINT='minio'
-STORAGE_S3_PORT=9000
+STORAGE_S3_ENDPOINT='seaweed'
+STORAGE_S3_PORT=8333
 STORAGE_S3_USE_SSL=false
 STORAGE_S3_PATH='/'
 STORAGE_S3_BUCKET='tf2-automatic'
-STORAGE_S3_ACCESS_KEY_ID='minioadmin'
-STORAGE_S3_SECRET_ACCESS_KEY='minioadmin'
+STORAGE_S3_ACCESS_KEY_ID='seaweedadmin'
+STORAGE_S3_SECRET_ACCESS_KEY='seaweedadmin'
 # Bot manager settings
 BOT_MANAGER_ENABLED=true
 BOT_MANAGER_URL='http://bot-manager:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-base-bot: &base-bot
   depends_on:
     - rabbitmq
     - bot-manager
-    - minio
+    - seaweed
   expose:
     - '3000'
   environment: &rmq-redis-env	
@@ -20,7 +20,7 @@ x-base-bot: &base-bot
 volumes:
   rabbitmq:
   redis:
-  minio:
+  seaweed-data:
 
 services:
   rabbitmq:
@@ -42,23 +42,36 @@ services:
       start_period: 30s
       start_interval: 10s
 
-  minio:
-    image: minio/minio:RELEASE.2023-02-17T17-52-43Z
-    command: server /data --console-address ":9001"
-    expose:
-      - '9000'
+  # Init container to create the bucket in SeaweedFS before the bots start
+  seaweed-init:
+    image: curlimages/curl
+    user: root
+    command: >
+      sh -c "
+        echo 'Waiting for Filer...';
+        until curl -s http://seaweed:8888/ > /dev/null; do sleep 2; done;
+        echo 'Creating bucket...';
+        curl -X POST http://seaweed:8888/buckets/tf2-automatic/;
+        echo 'Done!';
+      "
+
+  seaweed:
+    image: chrislusf/seaweedfs:latest
+    restart: unless-stopped
+    command: 'server -s3 -s3.config=/etc/seaweedfs/s3_config.json -dir=/data -s3.allowEmptyFolder=true'
     ports:
-      - '9001:9001'
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      - '8333:8333' # S3 API
+      - '9333:9333' # Master UI
+      - '8888:8888' # Filer UI
     volumes:
-      - 'minio:/data'
+      - 'seaweed-data:/data'
+      - './s3_config.json:/etc/seaweedfs/s3_config.json:ro'
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9333/cluster/status"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 0s
 
   redis:
     image: redis:alpine

--- a/template.s3_config.json
+++ b/template.s3_config.json
@@ -1,0 +1,20 @@
+{
+  "identities": [
+    {
+      "name": "admin",
+      "credentials": [
+        {
+          "accessKey": "seaweedadmin",
+          "secretKey": "seaweedadmin"
+        }
+      ],
+      "actions": [
+        "Read",
+        "Write",
+        "List",
+        "Tagging",
+        "Admin"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Storage Backend Migration:**

* Replaced MinIO with SeaweedFS as the S3-compatible storage service in `docker-compose.yml`, including new service definitions for `seaweed` and an initialization container to create the required bucket before bots start.

* Updated the storage configuration in `bots/template.env` to use SeaweedFS endpoints, ports, and credentials (`seaweedadmin`).

**Configuration and Documentation Updates:**

* Added a new `template.s3_config.json` file to provide a template for SeaweedFS S3 identity and credentials configuration.

* Updated the `README.md` to instruct users to create `s3_config.json` from the new template and ensure Seaweed credentials match those in bot environment files, removing references to MinIO and its manual setup steps.